### PR TITLE
feat: update StackTile chips and headline copy

### DIFF
--- a/components/tiles/StackTile.vue
+++ b/components/tiles/StackTile.vue
@@ -8,7 +8,7 @@
         <span class="w-1.5 h-1.5 rounded-full inline-block" style="background-color: var(--tile-light-text);" />
         Stack
       </span>
-      <h4 class="font-display text-[22px] mt-2 mb-0 font-normal tracking-[-0.01em]" style="color: inherit;">Tools I reach for, daily.</h4>
+      <h4 class="font-display text-[22px] mt-2 mb-0 font-normal tracking-[-0.01em]" style="color: inherit;">Tools I reach for, first.</h4>
     </div>
     <div class="flex-1 overflow-hidden relative marquee-mask">
       <div class="flex gap-3.5 marquee-track w-max py-3.5">
@@ -22,6 +22,6 @@
   </div>
 </template>
 <script setup>
-const chips = ['Vue','Nuxt','TypeScript','Node.js','PHP','.NET','Tailwind','Webflow','WordPress','Postgres','MySQL','Figma']
+const chips = ['Vue','Nuxt','Tailwind','Node.js','.NET','PHP','Webflow','WordPress','MySQL','MongoDB','GraphQL','Docker','Azure','GitHub','GitLab','Netlify','Cloudflare','Claude','Codex','OpenCode','Copilot','VS Code']
 const doubled = [...chips, ...chips]
 </script>


### PR DESCRIPTION
Updates the StackTile component:\n\n- Headline changed from \"Tools I reach for, daily.\" → \"Tools I reach for, first.\"\n- Chips updated to 22 tools ordered by type: frontend, backend, CMS, data, devops/cloud, AI, editor

---
_Generated by [Claude Code](https://claude.ai/code/session_015ySdomzcYZJEfDKrsgMN1S)_